### PR TITLE
feat: better error messages and hide custom link creator

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -91,7 +91,7 @@ const App = () => {
                 />
                 <Switch>
                     <Route exact path="/shorten">
-                        <Shorten userMandates={userMandates} />
+                        <Shorten userMandates={userMandates} pls={pls} hasToken={hasToken} />
                     </Route>
                     <Route exact path="/links">
                         <Links user={user} userMandates={userMandates} allMandates={allMandates} pls={pls} allGroups={allGroups} />

--- a/client/src/common/permissions.js
+++ b/client/src/common/permissions.js
@@ -1,0 +1,10 @@
+
+export const hasPermission = (userPermissions, permission) => {
+    return userPermissions.includes(permission);
+};
+
+export const hasPermissionsOr = (userPermissions, permissions) => {
+    return permissions.reduce((result, permission) => {
+        return hasPermission(userPermissions, permission) || result;
+    }, false);
+};

--- a/client/src/components/LinkCreator.js
+++ b/client/src/components/LinkCreator.js
@@ -22,7 +22,7 @@ const useStyles = createStyles(() => ({
     }
 }));
 
-const LinkCreator = ({ title, desc, custom, userMandates }) => {
+const LinkCreator = ({ title, desc, custom, userMandates, disabled }) => {
 
     const { classes } = useStyles();
     const [radio, setRadio] = useState("no");
@@ -102,19 +102,19 @@ const LinkCreator = ({ title, desc, custom, userMandates }) => {
                     className={classes.input}
                     placeholder="Lång jävla länk"
                     {...form.getInputProps("url")}
-                    disabled={fetching}
+                    disabled={fetching || disabled}
                 />
                 {custom &&
                     <TextInput
                         className={classes.input}
                         placeholder="Önskad förkortad länk"
                         {...form.getInputProps("short")}
-                        disabled={fetching}
+                        disabled={fetching || disabled}
                     />
                 }
                 <RadioGroup label="Utgångsdatum" value={radio} onChange={setRadio}>
-                    <Radio value="yes" label="Ja" disabled={fetching} />
-                    <Radio value="no" label="Nej" disabled={fetching} />
+                    <Radio value="yes" label="Ja" disabled={fetching || disabled} />
+                    <Radio value="no" label="Nej" disabled={fetching || disabled} />
                 </RadioGroup>
                 <div className={classes.date}>
                     {radio === "yes" &&
@@ -122,7 +122,7 @@ const LinkCreator = ({ title, desc, custom, userMandates }) => {
                             id="expire-time"
                             type="datetime-local"
                             {...form.getInputProps("expire")}
-                            disabled={fetching}
+                            disabled={fetching || disabled}
                         />
                     }
                 </div>
@@ -147,12 +147,12 @@ const LinkCreator = ({ title, desc, custom, userMandates }) => {
                             searchable
                             allowDeselect
                             {...form.getInputProps("mandate")}
-                            disabled={fetching}
+                            disabled={fetching || disabled}
                             autoComplete="off"
                         />
                     </div>
                 }
-                <Button type="submit" disabled={submitDisabled || fetching}>Förkorta</Button>
+                <Button type="submit" disabled={submitDisabled || fetching || disabled}>Förkorta</Button>
             </form>
             {result &&
                 <>

--- a/client/src/views/Shorten.js
+++ b/client/src/views/Shorten.js
@@ -2,21 +2,33 @@ import React, { useEffect, useState } from "react";
 import { Header } from "methone";
 import axios from "axios";
 import LinkCreator from "../components/LinkCreator";
+import { hasPermissionsOr } from "../common/permissions";
+import { Alert } from "@mantine/core";
 
-const Shorten = ({ userMandates }) => {
+const Shorten = ({ userMandates, pls, hasToken }) => {
 
     return (
         <>
             <Header title="Länkförkortare" />
             <div id="content">
+                {!hasToken &&
+                    <Alert
+                        title="Du är inte inloggad"
+                        color="blue"
+                    >
+                        Logga in för att förkorta länkar
+                    </Alert>
+                }
                 <div style={{ marginBottom: "25px", display: "flex", flexDirection: "column" }}>
                     <p>Trött på långa länkar? Då har vi systemet just för dig. Stoppa in din långa länk, klicka på "Förkorta" och vips har du en länk man lätt kommer ihåg.</p>
                     <p>Du kan testa genom att stoppa in example.com</p>
                     <p><b>Detta system får bara användas i sektionsrelaterade ändamål. Du måste vara inloggad för att kunna förkorta en länk.</b></p>
                     <p>Tänk på vad som finns i länken du förkortar. Se till att länken inte innehåller några personliga tokens eller liknande.</p>
+                    <p>För att kunna specificera en förkortad länk, exempelvis "ior", måste du vara funktionär. Om du trots detta vill kunna specificera förkortade länkar för ett sektionsenligt ändamål, kontakta systemansvarig.</p>
                 </div>
                 <LinkCreator
                     title="Autogenererad förkortad länk"
+                    disabled={!hasToken}
                     desc={
                         <>
                             <p>Slumpa en fyra karaktärer lång sträng.</p>
@@ -24,17 +36,19 @@ const Shorten = ({ userMandates }) => {
                     }
                     userMandates={userMandates}
                 />
-                <LinkCreator
-                    title="Specificera förkortad länk"
-                    desc={
-                        <>
-                            <p>Önska en förkortad länk, exempelvis "ior". Giltiga tecken: A-Ö, a-ö, 0-9</p>
-                            <p>Används för exempelvis rekryteringsformulär för nämnder. Du måste vara funktionär för att nyttja denna funktionalitet.</p>
-                        </>
-                    }
-                    custom
-                    userMandates={userMandates}
-                />
+                {hasPermissionsOr(pls, ["admin", "custom-link"]) &&
+                    <LinkCreator
+                        title="Specificera förkortad länk"
+                        desc={
+                            <>
+                                <p>Önska en förkortad länk, exempelvis "ior". Giltiga tecken: A-Ö, a-ö, 0-9</p>
+                                <p>Används för exempelvis rekryteringsformulär för nämnder. Du måste vara funktionär för att nyttja denna funktionalitet.</p>
+                            </>
+                        }
+                        custom
+                        userMandates={userMandates}
+                    />
+                }
             </div>
         </>
     )

--- a/middlewares.js
+++ b/middlewares.js
@@ -45,7 +45,7 @@ export const authorizePls = async (req, res, next) => {
 
         next();
     } catch (err) {
-        res.sendStatus(401);
+        res.sendStatus(500);
         return;
     }
 };
@@ -55,7 +55,7 @@ export const desiredAuth = (req, res, next) => {
         if (req.user.pls.includes("custom-link") || req.user.pls.includes("admin")) {
             return next();
         }
-        res.sendStatus(401);
+        res.sendStatus(403);
     } else {
         next();
     }
@@ -64,7 +64,7 @@ export const desiredAuth = (req, res, next) => {
 export const adminAuth = async (req, res, next) => {
     if (req.user.pls.includes("admin")) return next();
 
-    res.sendStatus(401);
+    res.sendStatus(403);
 };
 
 // Checks authorization but does not reject.


### PR DESCRIPTION
Att gömma hela systemet bakom auth kommer göra att man måste logga in för att besöka en förkortad länk, därför lade jag inte till det.

- Gömmer custom link creation när man inte är inloggad
- Link creation form disabled när man inte är inloggad
- Inforuta om att man inte är inloggad högst upp
- Returnera 403 när man inte har rättigheter att skapa en custom short link

Closes: #18 