### PR TITLE
Make links visible on firefox

### DIFF
--- a/client/src/components/ItemBrowser.js
+++ b/client/src/components/ItemBrowser.js
@@ -170,7 +170,7 @@ const ItemBrowser = ({
                             }}
                         >
                             <DataGrid
-                                style={{ height: "100%" }}
+                                style={{ blockSize: "100%", contain: "content" }}
                                 columns={columns}
                                 rows={itemsOnCurrentPage}
                                 selectedRows={selectedRows}

--- a/client/src/components/ItemBrowser.js
+++ b/client/src/components/ItemBrowser.js
@@ -171,6 +171,7 @@ const ItemBrowser = ({
                         >
                             <DataGrid
                                 style={{ blockSize: "100%", contain: "content" }}
+                                className="rdg-light"
                                 columns={columns}
                                 rows={itemsOnCurrentPage}
                                 selectedRows={selectedRows}


### PR DESCRIPTION
This fix is a bit hacky since it overrides the styling of react-data-grid.

Does not seem to make any difference on chrome (Chromium 112.0.5615.50 to be exact).

Also enforces light mode on the list of links, since the rest of the page has a light theme anyhow.

Fixes #20 