### PR TITLE
Add force flag in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,3 +33,4 @@ jobs:
         remote-branch: 'master'
         dokku-host: 'medusa.datasektionen.se'
         app-name: 'dsekt.se'
+        git-push-flags: '--force'


### PR DESCRIPTION
So that if someone force-pushes or something like that the deployment doesn't have to break until it's fixed manually